### PR TITLE
Add '__add__' magic method to 'Namespace' class.

### DIFF
--- a/bindings/python/lilv.py
+++ b/bindings/python/lilv.py
@@ -1108,13 +1108,16 @@ class Nodes(Collection):
 class Namespace:
     """Namespace prefix.
 
-    Use attribute syntax to easily create URIs within this namespace, for
-    example::
+    Use attribute syntax or the addition operator to easily create URIs
+    within this namespace, for example::
 
        >>> world = lilv.World()
        >>> ns = Namespace(world, "http://example.org/")
        >>> print(ns.foo)
        http://example.org/foo
+       >>> print(ns + '#bar')
+       http://example.org/#foo
+
     """
 
     def __init__(self, world, prefix):
@@ -1123,6 +1126,9 @@ class Namespace:
 
         self.world = world
         self.prefix = prefix
+
+    def __add__(self, suffix):
+        return self.world.new_uri(self.prefix + suffix)
 
     def __eq__(self, other):
         return str(self) == str(other)


### PR DESCRIPTION
This allows to create URIs from a `Namespace` instance by adding a suffix
with the addition (`+`) operator.

Example:

```
>>> import lilv
>>> w = lilv.World()
>>> ns = lilv.Namespace(w, 'http://example.com/')
>>> print(ns + '#foo')
http://example.com/#foo
```

Signed-off-by: Christopher Arndt <chris@chrisarndt.de>