### PR TITLE
[WIN32] Always use CreateSymbolicLink() wrapper.

### DIFF
--- a/src/lilv_internal.h
+++ b/src/lilv_internal.h
@@ -34,9 +34,6 @@ extern "C" {
 #include <stdlib.h>
 
 #ifdef _WIN32
-#    undef _WIN32_WINNT
-/** Force XP/2003 for excluding CreateSymbolicLinkA/W **/
-#    define _WIN32_WINNT 0x0500
 #    include <windows.h>
 #    include <direct.h>
 #    include <stdio.h>

--- a/src/lilv_internal.h
+++ b/src/lilv_internal.h
@@ -34,13 +34,18 @@ extern "C" {
 #include <stdlib.h>
 
 #ifdef _WIN32
+#    undef _WIN32_WINNT
+/** Force XP/2003 for excluding CreateSymbolicLinkA/W **/
+#    define _WIN32_WINNT 0x0500
 #    include <windows.h>
 #    include <direct.h>
 #    include <stdio.h>
+#    include <io.h>
 #    define dlopen(path, flags) LoadLibrary(path)
 #    define dlclose(lib)        FreeLibrary((HMODULE)lib)
 #    define unlink(path)        _unlink(path)
 #    define rmdir(path)         _rmdir(path)
+#    define mkdir(path, flags)  _mkdir(path)
 #    ifdef _MSC_VER
 #        define __func__ __FUNCTION__
 #        ifndef snprintf

--- a/src/util.c
+++ b/src/util.c
@@ -39,9 +39,14 @@ _CreateSymbolicLink(LPCTSTR linkpath, LPCTSTR targetpath, DWORD flags)
 {
 	typedef BOOLEAN (WINAPI* PFUNC)(LPCTSTR, LPCTSTR, DWORD);
 
-	PFUNC pfn = (PFUNC)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
-	                                  "CreateSymbolicLinkA");
-	return pfn ? pfn(linkpath, targetpath, flags) : 0;
+	static PFUNC pfn = NULL;
+
+	if (pfn == NULL) {
+		pfn = (PFUNC)GetProcAddress(GetModuleHandle(TEXT("kernel32.dll")),
+		                            "CreateSymbolicLinkA");
+		if (pfn == NULL) return 0;
+	}
+	return pfn(linkpath, targetpath, flags);
 }
 #else
 #    include <dirent.h>

--- a/src/util.c
+++ b/src/util.c
@@ -29,16 +29,8 @@
 #include "serd/serd.h"
 
 #ifdef _WIN32
-#ifndef _WIN32_WINNT
-#    define _WIN32_WINNT 0x0600  /* for CreateSymbolicLink */
-#endif
-#    include <windows.h>
-#    include <direct.h>
-#    include <io.h>
 #    define F_OK 0
-#    define mkdir(path, flags) _mkdir(path)
-#    if (defined(_MSC_VER) && _MSC_VER <= 1400) || defined(__MINGW64__) || defined(__MINGW32__)
-/** Implement 'CreateSymbolicLink()' for MSVC 8 or earlier */
+/** Implement 'CreateSymbolicLink()' for Windows XP/2003 and earlier */
 #ifdef __cplusplus
 extern "C"
 #endif
@@ -51,7 +43,6 @@ CreateSymbolicLink(LPCTSTR linkpath, LPCTSTR targetpath, DWORD flags)
 	                                  "CreateSymbolicLinkA");
 	return pfn ? pfn(linkpath, targetpath, flags) : 0;
 }
-#    endif
 #else
 #    include <dirent.h>
 #    include <unistd.h>

--- a/src/util.c
+++ b/src/util.c
@@ -35,7 +35,7 @@
 extern "C"
 #endif
 static BOOLEAN WINAPI
-CreateSymbolicLink(LPCTSTR linkpath, LPCTSTR targetpath, DWORD flags)
+_CreateSymbolicLink(LPCTSTR linkpath, LPCTSTR targetpath, DWORD flags)
 {
 	typedef BOOLEAN (WINAPI* PFUNC)(LPCTSTR, LPCTSTR, DWORD);
 
@@ -485,7 +485,7 @@ lilv_symlink(const char* oldpath, const char* newpath)
 	int ret = 0;
 	if (strcmp(oldpath, newpath)) {
 #ifdef _WIN32
-		ret = !CreateSymbolicLink(newpath, oldpath, 0);
+		ret = !_CreateSymbolicLink(newpath, oldpath, 0);
 		if (ret) {
 			ret = !CreateHardLink(newpath, oldpath, 0);
 		}


### PR DESCRIPTION
By forcing macro `_WIN32_WINNT` to be 0x500, the declarations of CreateSymbolicLinkA/W and CreateSymbolicLink are excluded from PSDK, WDK or W32API. This resolves all troubles with toolchains, compiler versions and it allows the library to run even on older platforms like NT and XP.
This a function that works with the filesystem so, in my opinion, using a wrapper is not a problem even in terms of performance.
However, the previous source had a bug and some code into `src/util.c` was useless, because `windows.h` is already included into `lilv_internal.h`. For this reason, `CreateSymbolicLink()` from system includes was NEVER used before.
So, I would like to suggest to fix `lilv_internal.h` by setting correctly the version and I took the chance to move also `mkdir()` macro from `src/util.c` to `lilv_internal.h`.