### PR TITLE
Bindings: allow using structures on connect_port as data parameter

### DIFF
--- a/bindings/python/lilv.py
+++ b/bindings/python/lilv.py
@@ -1460,6 +1460,10 @@ class Instance(Structure):
             self.get_descriptor().connect_port(
                 self.get_handle(), port_index, data
             )
+        elif isinstance(data, Structure):
+            self.get_descriptor().connect_port(
+                self.get_handle(), port_index, cast(byref(data), c_void_p)
+            )
         elif type(data) == numpy.ndarray:
             self.get_descriptor().connect_port(
                 self.get_handle(),


### PR DESCRIPTION
Adds the possibility for Atom implementations by the user.