### PR TITLE
Fix include error when building on windows with dyn-manifest enabled

### DIFF
--- a/src/world.c
+++ b/src/world.c
@@ -29,7 +29,6 @@
 
 #ifdef LILV_DYN_MANIFEST
 #  include "lv2/dynmanifest/dynmanifest.h"
-#  include <dlfcn.h>
 #endif
 
 #include <assert.h>


### PR DESCRIPTION
When building on Windows with `LILV_DYN_MANIFEST`, the dlfcn.h header cannot be found. Luckily, the lilv_internal.h header already includes a workaround, so we can just remove the duplicate include in world.c.